### PR TITLE
[style] 명함 사이즈 조정

### DIFF
--- a/src/components/CardTheme/Theme1/style.ts
+++ b/src/components/CardTheme/Theme1/style.ts
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
 
 export const Container = styled.div`
-  width: 340.16px;
-  height: 188.98px;
+  width: 328px;
+  height: 189px;
   padding: 31px 28px 28px;
   display: flex;
   justify-content: space-between;

--- a/src/components/CardTheme/Theme2/style.ts
+++ b/src/components/CardTheme/Theme2/style.ts
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
 
 export const Container = styled.div`
-  width: 340.16px;
-  height: 188.98px;
+  width: 328px;
+  height: 189px;
   padding: 31px 28px 28px 38px;
   display: flex;
   justify-content: space-between;

--- a/src/components/CardTheme/Theme3/style.ts
+++ b/src/components/CardTheme/Theme3/style.ts
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
 
 export const Container = styled.div`
-  width: 188.98px;
-  height: 340.16px;
+  width: 189px;
+  height: 328px;
   padding: 24px 27px 28px;
   display: flex;
   gap: 36px;

--- a/src/components/CardTheme/Theme4/style.ts
+++ b/src/components/CardTheme/Theme4/style.ts
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
 
 export const Container = styled.div`
-  width: 188.98px;
-  height: 340.16px;
+  width: 189px;
+  height: 328px;
   padding: 24px 27px 28px;
   display: flex;
   gap: 36px;


### PR DESCRIPTION
## 개요 💡

명함 케이스에 들어가도록 명함 사이즈 조정했습니다

## 작업내용 ⌨️

- 가로 명함 width: 328px, height: 189px 으로 통일
- 세로 명함 width: 189px, height: 328px 으로 통일