### PR TITLE
[hotfix] 세로명함 로고 위치 조정

### DIFF
--- a/src/components/CardTheme/Theme3/index.tsx
+++ b/src/components/CardTheme/Theme3/index.tsx
@@ -16,7 +16,7 @@ const Theme3: React.FC<CardContentProps> = ({
 
   return (
     <S.Container>
-      <GSMLogo top='264px' left='20px' />
+      <GSMLogo top='252px' left='20px' />
       <S.UserImage imageUrl={imageUrl} />
       <S.UserInfoContainer>
         <T.MainInfoBox>

--- a/src/components/CardTheme/Theme4/index.tsx
+++ b/src/components/CardTheme/Theme4/index.tsx
@@ -16,7 +16,7 @@ const Theme4: React.FC<CardContentProps> = ({
 
   return (
     <S.Container>
-      <GSMLogo top='264px' left='20px' />
+      <GSMLogo top='252px' left='20px' />
       <S.UserImage imageUrl={imageUrl} />
       <S.UserInfoContainer>
         <T.MainInfoBox>


### PR DESCRIPTION
## 개요 💡

세로명함에 있는 로고의 위치를 조정했습니다

## 작업내용 ⌨️

- 세로명함에 있는 GSMLogo 컴포넌트의 props(top) 값을 변경했습니다.
