### PR TITLE
[hotfix] 변환 중에는 '다음으로' 버튼 비활성화

### DIFF
--- a/src/pageContainers/ConvertPage/index.tsx
+++ b/src/pageContainers/ConvertPage/index.tsx
@@ -32,28 +32,32 @@ const ConvertPage: React.FC<Props> = ({
     디즈니: `A 3D animated portrait in the exact style of a Disney or Pixar character, inspired by movies like Tangled, Frozen, and Encanto. The character has extremely large and expressive eyes, a small nose, soft rounded facial features, and slightly exaggerated proportions. The skin is flawless and glowing, with soft lighting and a dreamy fairytale color palette. The expression is kind and charming, like a Disney princess or prince. Rendered with cinematic lighting and studio-quality background. Stylized, not realistic. Disney 3D animation look, not anime or cartoon.`,
     마인크래프트: `Convert this image into Minecraft style: voxel art, pixelated blocks, low resolution textures, cubic shapes, blocky environment, bright lighting, 2D Minecraft aesthetic.`,
     스누피: `Face illustration in Peanuts cartoon style, minimal lines, round head, small dot eyes, simple mouth, flat colors, inspired by Snoopy and Charlie Brown comics. No shading, no realism.`,
-    심슨: `Convert this person into a character in *The Simpsons* TV show. Use flat 2D cartoon style with thick black outlines and a limited color palette. The character must have bright yellow skin, large round white eyes with black pupils, a wide overbite, and a comically exaggerated facial expression. Style the hair in blocky or spiky cartoon shapes. Use only flat shading — no gradients or 3D effects. Ensure the character looks like it belongs in a screenshot from The Simpsons, standing in Springfield with the show’s signature humor and satirical American cartoon vibe. No realism, no anime, no webtoon — only classic Simpsons art style.`,
+    심슨: `Convert this person into a character in *The Simpsons* TV show. Use flat 2D cartoon style with thick black outlines and a limited color palette. The character must have bright yellow skin, large round white eyes with black pupils, a wide overbite, and a comically exaggerated facial expression. Style the hair in blocky or spiky cartoon shapes. Use only flat shading — no gradients or 3D effects. Ensure the character looks like it belongs in a screenshot from The Simpsons, standing in Springfield with the show's signature humor and satirical American cartoon vibe. No realism, no anime, no webtoon — only classic Simpsons art style.`,
     레고: `"A scene in LEGO style: made of colorful plastic bricks, blocky shapes with visible studs, glossy plastic texture, modular toy design, bright primary colors, highly detailed, resembling LEGO minifigures and LEGO structures`,
   };
 
   const handleNextButtonClick = () => {
-    if (selectedButton === null)
+    if (selectedButton === null) {
       return toast.error('예, 아니오 중 하나를 선택해 주셔야해요.');
+    }
 
-    if (
-      (selectedButton === SelectedType.YES && !isLoading) ||
-      selectedButton === SelectedType.NO
-    )
+    if (selectedButton === SelectedType.NO) {
       setFlow(Flow.SELECT_THEME_FLOW);
-    else {
-      return toast.error('아직 변환된 사진이 로딩되지 않았습니다');
+      return;
+    }
+
+    if (selectedButton === SelectedType.YES) {
+      if (!convertedImageUrl) {
+        convertImage();
+        return;
+      }
+      setFlow(Flow.SELECT_THEME_FLOW);
     }
   };
 
   const handleModalButtonClick = () => setIsModal(false);
   const handlePreviewButtonClick = () => {
     if (selectedButton !== null) {
-      convertImage();
       setIsModal(true);
     } else {
       toast.error('예, 아니요 중 하나를 선택해 주셔야해요.');
@@ -142,10 +146,25 @@ const ConvertPage: React.FC<Props> = ({
       <S.ButtonBox>
         <S.BackButton onClick={handleBackButtonClick}>다시찍기</S.BackButton>
         <S.ButtonWrapper>
-          <S.PreviewButton onClick={handlePreviewButtonClick}>
-            미리보기
-          </S.PreviewButton>
-          <S.NextButton onClick={handleNextButtonClick}>다음으로</S.NextButton>
+          {(selectedButton === SelectedType.NO ||
+            (selectedButton === SelectedType.YES &&
+              (isLoading || convertedImageUrl))) && (
+            <S.PreviewButton onClick={handlePreviewButtonClick}>
+              미리보기
+            </S.PreviewButton>
+          )}
+          <S.NextButton
+            onClick={handleNextButtonClick}
+            disabled={selectedButton === SelectedType.YES && isLoading}
+          >
+            {selectedButton === SelectedType.YES
+              ? isLoading
+                ? '변환 중...'
+                : convertedImageUrl
+                  ? '다음으로'
+                  : '변환하기'
+              : '다음으로'}
+          </S.NextButton>
         </S.ButtonWrapper>
       </S.ButtonBox>
       {isModal && (

--- a/src/pageContainers/ConvertPage/index.tsx
+++ b/src/pageContainers/ConvertPage/index.tsx
@@ -33,7 +33,7 @@ const ConvertPage: React.FC<Props> = ({
     마인크래프트: `Convert this image into Minecraft style: voxel art, pixelated blocks, low resolution textures, cubic shapes, blocky environment, bright lighting, 2D Minecraft aesthetic.`,
     스누피: `Face illustration in Peanuts cartoon style, minimal lines, round head, small dot eyes, simple mouth, flat colors, inspired by Snoopy and Charlie Brown comics. No shading, no realism.`,
     심슨: `Convert this person into a character in *The Simpsons* TV show. Use flat 2D cartoon style with thick black outlines and a limited color palette. The character must have bright yellow skin, large round white eyes with black pupils, a wide overbite, and a comically exaggerated facial expression. Style the hair in blocky or spiky cartoon shapes. Use only flat shading — no gradients or 3D effects. Ensure the character looks like it belongs in a screenshot from The Simpsons, standing in Springfield with the show's signature humor and satirical American cartoon vibe. No realism, no anime, no webtoon — only classic Simpsons art style.`,
-    레고: `"A scene in LEGO style: made of colorful plastic bricks, blocky shapes with visible studs, glossy plastic texture, modular toy design, bright primary colors, highly detailed, resembling LEGO minifigures and LEGO structures`,
+    레고: `A scene in LEGO style: made of colorful plastic bricks, blocky shapes with visible studs, glossy plastic texture, modular toy design, bright primary colors, highly detailed, resembling LEGO minifigures and LEGO structures`,
   };
 
   const handleNextButtonClick = () => {

--- a/src/pageContainers/ConvertPage/style.ts
+++ b/src/pageContainers/ConvertPage/style.ts
@@ -49,6 +49,13 @@ export const NextButton = styled.button`
   border-radius: 0.5rem;
   width: 7.875rem;
   height: 3rem;
+
+  &:disabled {
+    background-color: ${({ theme }) => theme.color.white};
+    border: ${({ theme }) => `0.0625rem solid ${theme.color.gray[40]}`};
+    color: ${({ theme }) => theme.color.gray[70]};
+    cursor: not-allowed;
+  }
 `;
 
 export const PreviewButton = styled(NextButton)`
@@ -110,7 +117,7 @@ export const ImgWrapper = styled.div`
 
 export const LoadingSpinner = styled.div`
   border: 0.3125rem solid rgba(0, 0, 0, 0.1);
-  border-left-color: ${({ theme }) => theme.color.gray[50]};
+  border-left-color: ${({ theme }) => theme.color.gray[70]};
   border-radius: 50%;
   width: 3.125rem;
   height: 3.125rem;


### PR DESCRIPTION
## 개요 💡

이미지 변환 전, 변환 중일 때 다음으로 넘어가면 명함에 사진이 뜨지않는 문제 해결했습니다.

## 작업내용 ⌨️

- 변환을 선택했을 때는 '변환하기' 버튼을 누르고 변환이 끝나기 전까지는 다음으로 못 넘어가도록 변경
- '변환하기' 버튼을 누르기 전에는 미리보기가 안 뜨도록 변경