### PR TITLE
[feat] 스타일 선택 버튼 유동 레이아웃 적용

### DIFF
--- a/src/components/PromptSelector/style.ts
+++ b/src/components/PromptSelector/style.ts
@@ -32,7 +32,7 @@ export const Prompt = styled.button<{ isSelected: boolean }>`
     isSelected ? theme.color.white : theme.color.gray[70]};
   border-radius: 0.5rem;
   display: inline-flex;
-  padding: 0.5rem 1rem 0.375rem 1.0625rem;
+  padding: 0.5rem 1rem;
   justify-content: center;
   align-items: center;
 `;

--- a/src/components/PromptSelector/style.ts
+++ b/src/components/PromptSelector/style.ts
@@ -16,7 +16,8 @@ export const Title = styled.h2`
 
 export const PromptContainer = styled.div`
   display: flex;
-  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
 `;
 
 export const Prompt = styled.button<{ isSelected: boolean }>`
@@ -30,7 +31,7 @@ export const Prompt = styled.button<{ isSelected: boolean }>`
   color: ${({ isSelected, theme }) =>
     isSelected ? theme.color.white : theme.color.gray[70]};
   border-radius: 0.5rem;
-  display: flex;
+  display: inline-flex;
   padding: 0.5rem 1rem 0.375rem 1.0625rem;
   justify-content: center;
   align-items: center;

--- a/src/components/PromptSelector/style.ts
+++ b/src/components/PromptSelector/style.ts
@@ -5,7 +5,6 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2.5rem;
-  padding: 0 0.7188rem;
   box-sizing: border-box;
 `;
 


### PR DESCRIPTION
## 개요 💡

> [feat] 스타일 선택 버튼 줄바꿈 처리 작업을 했습니다.

## 작업내용 ⌨️

- 버튼 개수에 따라 자동 줄바꿈
- 변경된 디자인에 따라 Container의 좌우 padding 제거
- 변경된 디자인에 따라 스타일 선택 버튼 padding 값 조정 

## 화면 
아래는 제가 테스트를 위해 '지브리' 프롬프트를 임의로 추가한 화면입니다.
![image](https://github.com/user-attachments/assets/f7d4edfb-cd19-47b2-a7b4-46751cfe5416)

