### PR TITLE
[fix] 크롬 번역 시 YesOrNoButton 텍스트 줄 간격(gap) 문제 수정

### DIFF
--- a/src/components/YesOrNoButton/index.tsx
+++ b/src/components/YesOrNoButton/index.tsx
@@ -18,18 +18,20 @@ const YesOrNoButton: React.FC<Props> = ({
         isSelected={selectedButton === SelectedType.YES}
       >
         <OIcon />
-        네,
-        <br />
-        변환할게요!
+        <span>
+          네,
+          <div>변환할게요!</div>
+        </span>
       </S.Button>
       <S.Button
         onClick={() => setSelectedButton(SelectedType.NO)}
         isSelected={selectedButton === SelectedType.NO}
       >
         <XIcon />
-        아니요,
-        <br />
-        그대로 인쇄할게요!
+        <span>
+          아니요,
+          <div>그대로 인쇄할게요!</div>
+        </span>
       </S.Button>
     </S.YesOrNoBox>
   );


### PR DESCRIPTION
## 개요 💡

> Chrome 번역기 사용 시 발생하는 의도치 않은 gap을 제거했습니다.

## 화면
[변경 전]
![image](https://github.com/user-attachments/assets/a28df680-7806-4740-90f3-0f08248672b1)

[변경 후]
![image](https://github.com/user-attachments/assets/94370714-e075-456d-94c7-e4c1eec9a966)